### PR TITLE
Add `parse` option so you can provide a parser function to be run on the string to get the correct Type 

### DIFF
--- a/guzzle-derive/src/attr.rs
+++ b/guzzle-derive/src/attr.rs
@@ -5,12 +5,13 @@ use syn::{
     bracketed, parenthesized,
     parse::{Parse, ParseBuffer},
     punctuated::Punctuated,
-    Ident, LitStr, Token,
+    Expr, Ident, LitStr, Token,
 };
 
-#[derive(Debug, Default)]
+#[derive(Default)]
 pub struct GuzzleAttributes {
     pub keys: Keys,
+    pub parser: Option<Expr>,
 }
 
 impl GuzzleAttributes {
@@ -29,14 +30,15 @@ impl Parse for GuzzleAttributes {
         let mut guzzle_attributes = GuzzleAttributes::default();
         punctuated_attrs.into_iter().for_each(|attr| match attr {
             GuzzleAttribute::Keys(keys) => guzzle_attributes.keys = keys,
+            GuzzleAttribute::Parser(parser) => guzzle_attributes.parser = Some(parser),
         });
         Ok(guzzle_attributes)
     }
 }
 
-#[derive(Debug)]
 pub enum GuzzleAttribute {
     Keys(Keys),
+    Parser(Expr),
 }
 
 impl Parse for GuzzleAttribute {
@@ -50,10 +52,11 @@ impl Parse for GuzzleAttribute {
 
             match name_str.as_ref() {
                 "keys" => Ok(GuzzleAttribute::Keys(input.parse()?)),
+                "parser" => Ok(GuzzleAttribute::Parser(input.parse()?)),
                 _ => Err(input.error(format!("Unknown key: {}", name_str))),
             }
         } else {
-            Err(input.error("Atrributes must be listed as `key = value`"))
+            Err(input.error("Attributes must be listed as `key = value`"))
         }
     }
 }
@@ -150,6 +153,17 @@ mod tests {
         assert_eq!("key3", &iter.next().unwrap().value());
         assert_eq!("key4", &iter.next().unwrap().value());
         assert!(iter.next().is_none());
+        Ok(())
+    }
+
+    fn test_parser(s: String) -> String {
+        s
+    }
+
+    #[test]
+    fn parse_parser() -> Result<(), syn::Error> {
+        let token_stream = quote! { parser = test_parser };
+        let attribute: GuzzleAttribute = parse2(token_stream)?;
         Ok(())
     }
 }

--- a/guzzle-derive/src/attr.rs
+++ b/guzzle-derive/src/attr.rs
@@ -18,6 +18,12 @@ impl GuzzleAttributes {
     pub fn new() -> GuzzleAttributes {
         GuzzleAttributes::default()
     }
+
+    pub fn set_default_key_if_none(&mut self, ident: Ident) {
+        if self.keys.is_empty() {
+            self.keys = Keys(vec![LitStr::new(ident.to_string().as_str(), ident.span())])
+        }
+    }
 }
 
 impl Parse for GuzzleAttributes {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,57 +175,58 @@ mod tests {
         }
     }
 
-    //mod guzzle_meta_data_derive {
-    //    use crate::Guzzle;
-    //
-    //    #[derive(Default, Guzzle)]
-    //    struct AttributeDemo {
-    //        /// This field is not annotated, therefore its field is `basic` and its keys contain
-    //        /// one string which is the same as the name `basic`.
-    //        basic: String,
-    //        /// This field may be filled from multiple keys
-    //        #[guzzle(keys = ["one", "two"])]
-    //        listed_keys: String,
-    //        /// This field is not a string, you must provider a parser that will transform it into
-    //        /// the correct type
-    //        #[guzzle(parser = "my_parser")]
-    //        other_types: u64,
-    //        /// This field isn't a string and has multiple keys
-    //        #[guzzle(parser = my_parser, keys = ["three", "four"])]
-    //        other_types_with_listed_keys: u64,
-    //    }
-    //
-    //    #[test]
-    //    fn everything() {
-    //        use std::collections::HashMap;
-    //
-    //        fn my_parser(s: String) -> u64 {
-    //            s.parse().unwrap_or(0)
-    //        }
-    //
-    //        let test_data: HashMap<String, String> = vec![
-    //            ("basic".to_string(), "basic info".to_string()),
-    //            ("one".to_string(), "1".to_string()),
-    //            ("two".to_string(), "2".to_string()),
-    //            ("other_types".to_string(), "20".to_string()),
-    //            ("three".to_string(), "3".to_string()),
-    //            ("four".to_string(), "4".to_string()),
-    //        ]
-    //        .into_iter()
-    //        .collect();
-    //
-    //        let attribute_demo = AttributeDemo::default();
-    //
-    //        let remaining_data: Vec<(String, String)> = attribute_demo
-    //            .into_iter()
-    //            .filter_map(|v| tester.guzzle(v))
-    //            .collect();
-    //
-    //        assert_eq!(attribute_demo.basic, "basic info".to_string());
-    //        assert_eq!(attribute_demo.listed_keys, "2".to_string());
-    //        assert_eq!(attribute_demo.other_types, 20);
-    //        assert_eq!(attribute_demo.other_types_with_listed_keys, 4);
-    //    }
-    //}
+    mod guzzle_meta_data_derive {
+        use crate::Guzzle;
 
+        fn u64_parser(s: String) -> u64 {
+            s.parse().unwrap()
+        }
+
+        #[derive(Default, Guzzle)]
+        struct AttributeDemo {
+            /// This field is not annotated, therefore its field is `basic` and its keys contain
+            /// one string which is the same as the name `basic`.
+            basic: String,
+            /// This field may be filled from multiple keys
+            #[guzzle(keys = ["one", "two"])]
+            listed_keys: String,
+            /// This field is not a string, you must provider a parser that will transform it into
+            /// the correct type
+            #[guzzle(parser = u64_parser)]
+            other_types: u64,
+            /// This field isn't a string and has multiple keys
+            #[guzzle(parser = u64_parser, keys = ["three", "four"])]
+            other_types_with_listed_keys: u64,
+        }
+
+        #[test]
+        fn everything() {
+            use std::collections::HashMap;
+
+            fn my_parser(s: String) -> u64 {
+                s.parse().unwrap_or(0)
+            }
+
+            let test_data: Vec<(&str, String)> = vec![
+                ("basic", "basic info".to_string()),
+                ("one", "1".to_string()),
+                ("two", "2".to_string()),
+                ("other_types", "20".to_string()),
+                ("three", "3".to_string()),
+                ("four", "4".to_string()),
+            ];
+
+            let mut attribute_demo = AttributeDemo::default();
+
+            let remaining_data: Vec<(&str, String)> = test_data
+                .into_iter()
+                .filter_map(|v| attribute_demo.guzzle(v))
+                .collect();
+
+            //            assert_eq!(attribute_demo.basic, "basic info".to_string());
+            assert_eq!(attribute_demo.listed_keys, "2".to_string());
+            assert_eq!(attribute_demo.other_types, 20);
+            assert_eq!(attribute_demo.other_types_with_listed_keys, 4);
+        }
+    }
 }


### PR DESCRIPTION
* Add parse option so you can provide a parser function to be run on the string to get the correct Type
* Guzzle will now use the field name if no key is provided.
* ToDo: Add no-guzzle flag to turn off Guzzle